### PR TITLE
Adding labels to points, adding executable to get distances to a fitted plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ build/
 .idea
 cmake-build-debug/
 cmake-build-release/
+
+# Directory for point clouds
+pcds
+
+# Jupyter cache
+.ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ build/
 
 # CLion project files
 .idea
+cmake-build-debug/
+cmake-build-release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ add_executable(reconstruct reconstruction++.cpp
                            src/registration_estimation.cpp
 			   src/cmdline.cpp)
 
+add_executable(get_plane_distances src/get_plane_distances.cpp)
+
 target_link_libraries(reconstruct ${PCL_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(get_plane_distances ${PCL_LIBRARIES} ${Boost_LIBRARIES})
 
 add_subdirectory(interpolation_data_collection)

--- a/include/combine_datapackets.h
+++ b/include/combine_datapackets.h
@@ -6,12 +6,12 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-combine_datapackets_to_scans(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > > datapacket_clouds,
+combine_datapackets_to_scans(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL> > > datapacket_clouds,
                              const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > &quaternions,
                              const std::string path);
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-combine_datapackets_to_fragment(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > > datapacket_clouds,
+combine_datapackets_to_fragment(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL> > > datapacket_clouds,
                                 const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > &quaternions,
                                 const std::string path);
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/load_data.h
+++ b/include/load_data.h
@@ -24,7 +24,7 @@ number_of_directories(const std::string data_path);
 std::vector<pcl::PointCloud<pcl::PointXYZ> >
 load_fragments(const std::string fragments_path, const int fragments_number);
 
-std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > >
+std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL> > >
 load_datapackets(const std::string path);
 
 void read_quaternions_file( quart_vector_t& quaternions, const std::string path);

--- a/interpolation_data_collection/interpolation_vlp.cpp
+++ b/interpolation_data_collection/interpolation_vlp.cpp
@@ -301,7 +301,6 @@ int main( int argc, const char *const *argv )
 
             // adding rgb float to point cloud
             cloud.points[j].rgb = rgb;
-            cloud.points[j].
 
             // Increment counter
             j++;

--- a/interpolation_data_collection/interpolation_vlp.cpp
+++ b/interpolation_data_collection/interpolation_vlp.cpp
@@ -307,7 +307,7 @@ int main( int argc, const char *const *argv )
             // adding rgb float to point cloud
             cloud.points[j].rgb = rgb;
 
-            // adding
+            // adding the laser vertical component to the point label
             cloud.points[j].label = laser.vertical;
 
             // Increment counter

--- a/interpolation_data_collection/interpolation_vlp.cpp
+++ b/interpolation_data_collection/interpolation_vlp.cpp
@@ -50,6 +50,7 @@ void print_help (const char* prog_name)
                << "-o <int>       or: specify odometry number\n"
                << "-start <int>   Specify field of view start degree [0-359]\n"
                << "-end <int>     Specify field of view end degree [0-359]\n"
+               << "-v             Verbose. Add information to point which laser scanned it \n"
                << "\n\n";
 }
 
@@ -73,6 +74,7 @@ int main( int argc, const char *const *argv )
     std::ofstream imu_data;
     std::string fragment;
     std::string odometry;
+    int laser_num;
     int fov_start;
     int fov_end;
     bool write_pcd;
@@ -85,12 +87,15 @@ int main( int argc, const char *const *argv )
     char opt_s[] = "-start";
     char opt_e[] = "-end";
     char opt_h[] = "-h";
+    char opt_l[] = "-l";
 
     pcl::console::parse_argument(argc, (char**)argv, opt_d, directory);
     pcl::console::parse_argument(argc, (char**)argv, opt_f, fragment);
     pcl::console::parse_argument(argc, (char**)argv, opt_o, odometry);
     pcl::console::parse_argument(argc, (char**)argv, opt_s, fov_start);
     pcl::console::parse_argument(argc, (char**)argv, opt_e, fov_end);
+    pcl::console::parse_argument(argc, (char**)argv, opt_l, laser_num);
+
 
     // Check correct command line arguments
     if (pcl::console::find_switch(argc, (char**)argv, opt_h)) {
@@ -140,13 +145,13 @@ int main( int argc, const char *const *argv )
 
     // Setting correct fragment path
     if (pcl::console::find_switch(argc, (char**)argv, "-f")) {
-        path = "../../build/" + directory + "/fragments/fragment_" + fragment + "/";
+        path = "../../pcds/" + directory + "/fragments/fragment_" + fragment + "/";
         std::cout << "Writing to: fragment_" + fragment << "\n\n";
     }
 
     // Setting correct odometry path
     else if (pcl::console::find_switch(argc, (char**)argv, "-o")) {
-        path = "../../build/" + directory + "/odometry/odometry_" + odometry + "/";
+        path = "../../pcds/" + directory + "/odometry/odometry_" + odometry + "/";
         std::cout << "Writing to: odometry_" + odometry << "\n\n";
     }
 
@@ -224,6 +229,11 @@ int main( int argc, const char *const *argv )
         // Looping over laser by laser (0-15)
         for (const velodyne::Laser &laser : lasers) {
             // Distance, azimuth and vertical of laser
+            if (laser_num >= 0 && laser.id != laser_num) {
+                // if laser is specified, then only get
+                // from the one
+                continue;
+            }
             const auto distance = static_cast<double>( laser.distance );
             const double azimuth = (laser.azimuth * PI) / 180.0;
             const double vertical = (laser.vertical * PI) / 180.0;
@@ -291,6 +301,7 @@ int main( int argc, const char *const *argv )
 
             // adding rgb float to point cloud
             cloud.points[j].rgb = rgb;
+            cloud.points[j].
 
             // Increment counter
             j++;

--- a/reconstruction++.cpp
+++ b/reconstruction++.cpp
@@ -42,23 +42,31 @@ main(int argc, char **argv)
         std::cout << i << std::endl;
         std::string fragment = "fragment_" + std::to_string(i);
 
-        // Read quaternions 
+        // Read quaternions
+        std::cout << "Reading quaternions file..."<< std::endl;
         quart_vector_t quaternions_time;
         read_quaternions_file( quaternions_time,
                                data_dir + "/fragments/" + fragment + "/quaternions" );
+        std::cout << "Done." << std::endl;
 
-        // Interpolate quaternions 
+        // Interpolate quaternions
+        std::cout << "Interpolating quaternions..."<< std::endl;
         vector4d_t interpolated_quaternions;
         interpolate_quaternions( interpolated_quaternions, quaternions_time );
+        std::cout << "Done." << std::endl;
 
         // Load datapackets
+        std::cout << "Loading datapackets..."<< std::endl;
         std::vector<std::vector<point_cloud> >
             datapackets_clouds = load_datapackets(data_dir + "/fragments/" + fragment + "/datapackets");
+        std::cout << "Done." << std::endl;
 
         // Combine datapackets to fragment
+        std::cout << "Combining datapackets to fragment..."<< std::endl;
         combine_datapackets_to_fragment(datapackets_clouds,
                                         interpolated_quaternions,
                                         data_dir + "/fragments/" + fragment);
+        std::cout << "Done." << std::endl;
     }
 
     std::cout << std::endl << std::endl;
@@ -73,27 +81,36 @@ main(int argc, char **argv)
             std::string odometry = "odometry_" + std::to_string(i);
 
             // Read quaternions
+            std::cout << "Reading quaternions file..."<< std::endl;
             quart_vector_t quaternions_time;
             read_quaternions_file( quaternions_time,
                                    data_dir + "/odometry/" + odometry + "/quaternions" );
+            std::cout << "Done." << std::endl;
 
             // Interpolate quaternions
             vector4d_t interpolated_quaternions;
             interpolate_quaternions( interpolated_quaternions, quaternions_time );
+            std::cout << "Done." << std::endl;
 
             // Load datapackets
+            std::cout << "Loading datapackets..."<< std::endl;
             std::vector<std::vector<point_cloud> >
                 datapacket_clouds = load_datapackets(data_dir + "/odometry/" + odometry + "/datapackets");
+            std::cout << "Done." << std::endl;
 
             // Combine datapackets to scans
+            std::cout << "Combining datapackets to scans..."<< std::endl;
             combine_datapackets_to_scans(datapacket_clouds,
                                          interpolated_quaternions,
                                          data_dir + "/odometry/" + odometry);
+            std::cout << "Done." << std::endl;
 
             // Estimate translation
+            std::cout << "Estimating translation..."<< std::endl;
             Eigen::Vector3f translation{0, 0, 0};
             translation_estimation(data_dir + "/odometry/" + odometry + "/scans", translation);
             translations.push_back(translation);
+            std::cout << "Done." << std::endl;
         }
         std::cout << std::endl << std::endl;
 

--- a/reconstruction++.cpp
+++ b/reconstruction++.cpp
@@ -51,7 +51,7 @@ main(int argc, char **argv)
         vector4d_t interpolated_quaternions;
         interpolate_quaternions( interpolated_quaternions, quaternions_time );
 
-        // Load datapackets 
+        // Load datapackets
         std::vector<std::vector<point_cloud> >
             datapackets_clouds = load_datapackets(data_dir + "/fragments/" + fragment + "/datapackets");
 

--- a/reconstruction++.cpp
+++ b/reconstruction++.cpp
@@ -22,6 +22,7 @@
 #include "cmdline.h"
 
 typedef pcl::PointCloud<pcl::PointXYZ> point_cloud;
+typedef pcl::PointCloud<pcl::PointXYZL> point_cloud_w_labels;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -43,26 +44,26 @@ main(int argc, char **argv)
         std::string fragment = "fragment_" + std::to_string(i);
 
         // Read quaternions
-        std::cout << "Reading quaternions file..."<< std::endl;
+        std::cout << "Reading quaternions file..."<< std::flush;
         quart_vector_t quaternions_time;
         read_quaternions_file( quaternions_time,
                                data_dir + "/fragments/" + fragment + "/quaternions" );
         std::cout << "Done." << std::endl;
 
         // Interpolate quaternions
-        std::cout << "Interpolating quaternions..."<< std::endl;
+        std::cout << "Interpolating quaternions..."<< std::flush;
         vector4d_t interpolated_quaternions;
         interpolate_quaternions( interpolated_quaternions, quaternions_time );
         std::cout << "Done." << std::endl;
 
         // Load datapackets
         std::cout << "Loading datapackets..."<< std::endl;
-        std::vector<std::vector<point_cloud> >
+        std::vector<std::vector<point_cloud_w_labels> >
             datapackets_clouds = load_datapackets(data_dir + "/fragments/" + fragment + "/datapackets");
         std::cout << "Done." << std::endl;
 
         // Combine datapackets to fragment
-        std::cout << "Combining datapackets to fragment..."<< std::endl;
+        std::cout << "Combining datapackets to fragment..."<< std::flush;
         combine_datapackets_to_fragment(datapackets_clouds,
                                         interpolated_quaternions,
                                         data_dir + "/fragments/" + fragment);
@@ -81,32 +82,33 @@ main(int argc, char **argv)
             std::string odometry = "odometry_" + std::to_string(i);
 
             // Read quaternions
-            std::cout << "Reading quaternions file..."<< std::endl;
+            std::cout << "Reading quaternions file..."<< std::flush;
             quart_vector_t quaternions_time;
             read_quaternions_file( quaternions_time,
                                    data_dir + "/odometry/" + odometry + "/quaternions" );
             std::cout << "Done." << std::endl;
 
             // Interpolate quaternions
+            std::cout << "Interpolating quaternions..."<< std::flush;
             vector4d_t interpolated_quaternions;
             interpolate_quaternions( interpolated_quaternions, quaternions_time );
             std::cout << "Done." << std::endl;
 
             // Load datapackets
             std::cout << "Loading datapackets..."<< std::endl;
-            std::vector<std::vector<point_cloud> >
+            std::vector<std::vector<point_cloud_w_labels> >
                 datapacket_clouds = load_datapackets(data_dir + "/odometry/" + odometry + "/datapackets");
             std::cout << "Done." << std::endl;
 
             // Combine datapackets to scans
-            std::cout << "Combining datapackets to scans..."<< std::endl;
+            std::cout << "Combining datapackets to scans..."<< std::flush;
             combine_datapackets_to_scans(datapacket_clouds,
                                          interpolated_quaternions,
                                          data_dir + "/odometry/" + odometry);
             std::cout << "Done." << std::endl;
 
             // Estimate translation
-            std::cout << "Estimating translation..."<< std::endl;
+            std::cout << "Estimating translation..."<< std::flush;
             Eigen::Vector3f translation{0, 0, 0};
             translation_estimation(data_dir + "/odometry/" + odometry + "/scans", translation);
             translations.push_back(translation);

--- a/src/combine_datapackets.cpp
+++ b/src/combine_datapackets.cpp
@@ -12,7 +12,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 std::vector<std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>>
 quaternions_scan_assignment(const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > &quaternions,
-                            std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > > &datapacket_clouds)
+                            std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL> > > &datapacket_clouds)
 {
     int number, current_number = 0, last_number = 0;
     std::vector<std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > > quaternions_scans;
@@ -34,7 +34,7 @@ quaternions_scan_assignment(const std::vector<Eigen::Vector4d, Eigen::aligned_al
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-combine_datapackets_to_scans(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > > datapacket_clouds,
+combine_datapackets_to_scans(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL> > > datapacket_clouds,
                              const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > &quaternions,
                              const std::string path)
 {
@@ -45,7 +45,7 @@ combine_datapackets_to_scans(std::vector<std::vector<pcl::PointCloud<pcl::PointX
     for (std::size_t i = 0; i < datapacket_clouds.size(); ++i) {
         // Make transformation matrices from quaternions
         std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d> > transformation_matrices = make_transformation_matrices(quaternions_scans[i]);
-        pcl::PointCloud<pcl::PointXYZ>::Ptr datapackets_combined(new pcl::PointCloud<pcl::PointXYZ>);
+        pcl::PointCloud<pcl::PointXYZL>::Ptr datapackets_combined(new pcl::PointCloud<pcl::PointXYZL>);
         for (std::size_t j = 0; j < datapacket_clouds[i].size(); ++j) {
             pcl::transformPointCloud(datapacket_clouds[i][j], datapacket_clouds[i][j], transformation_matrices[j]);
             *datapackets_combined += datapacket_clouds[i][j];
@@ -60,13 +60,13 @@ combine_datapackets_to_scans(std::vector<std::vector<pcl::PointCloud<pcl::PointX
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-combine_datapackets_to_fragment(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > > datapacket_clouds,
+combine_datapackets_to_fragment(std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL> > > datapacket_clouds,
                                 const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > &quaternions,
                                 const std::string path)
 {
     const std::vector<std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>>
         quaternions_scans = quaternions_scan_assignment(quaternions, datapacket_clouds);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr datapackets_combined(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZL>::Ptr datapackets_combined(new pcl::PointCloud<pcl::PointXYZL>);
     std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d> > transformation_matrices;
     for (std::size_t i = 0; i < datapacket_clouds.size(); ++i) {
         // Make transformation matrices from quaternions
@@ -83,8 +83,8 @@ combine_datapackets_to_fragment(std::vector<std::vector<pcl::PointCloud<pcl::Poi
     // Visualize fragment
     pcl::visualization::PCLVisualizer viz;
     viz.setBackgroundColor(255, 255, 255);
-    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> cloud_color(datapackets_combined, 0, 255, 0);
-    viz.addPointCloud<pcl::PointXYZ>(datapackets_combined, cloud_color, "cloud 1");
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZL> cloud_color(datapackets_combined, 0, 255, 0);
+    viz.addPointCloud<pcl::PointXYZL>(datapackets_combined, cloud_color, "cloud 1");
     viz.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 0.5, "cloud 1");
     while (!viz.wasStopped ())
     {

--- a/src/combine_datapackets.cpp
+++ b/src/combine_datapackets.cpp
@@ -10,7 +10,7 @@
 #include "transformation.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-std::vector<std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > >
+std::vector<std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>>
 quaternions_scan_assignment(const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > &quaternions,
                             std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > > &datapacket_clouds)
 {
@@ -64,7 +64,7 @@ combine_datapackets_to_fragment(std::vector<std::vector<pcl::PointCloud<pcl::Poi
                                 const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > &quaternions,
                                 const std::string path)
 {
-    const std::vector<std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> > >
+    const std::vector<std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>>
         quaternions_scans = quaternions_scan_assignment(quaternions, datapacket_clouds);
     pcl::PointCloud<pcl::PointXYZ>::Ptr datapackets_combined(new pcl::PointCloud<pcl::PointXYZ>);
     std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d> > transformation_matrices;
@@ -86,6 +86,9 @@ combine_datapackets_to_fragment(std::vector<std::vector<pcl::PointCloud<pcl::Poi
     pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> cloud_color(datapackets_combined, 0, 255, 0);
     viz.addPointCloud<pcl::PointXYZ>(datapackets_combined, cloud_color, "cloud 1");
     viz.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 0.5, "cloud 1");
-    viz.spin();
+    while (!viz.wasStopped ())
+    {
+        viz.spinOnce ();
+    }
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/get_plane_distances.cpp
+++ b/src/get_plane_distances.cpp
@@ -1,0 +1,99 @@
+//
+// Created by Branislav Jenco on 21.09.2020.
+// Crop point cloud with minX/Y/Z and maxX/Y/Z boundaries, fit a plane and output a file with signed
+// distances between the fitted plane and points.
+// Assuming the cropped point cloud is of a flat surface to which a plane can be fitted.
+// The input must be a PointXYZL point cloud (with labels)
+//
+
+#include <pcl/point_cloud.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/filters/crop_box.h>
+#include <pcl/visualization/pcl_visualizer.h>
+
+#include <pcl/console/parse.h>
+#include <pcl/sample_consensus/ransac.h>
+#include <pcl/sample_consensus/sac_model_plane.h>
+
+#include <iostream>
+#include <fstream>
+
+typedef pcl::PointCloud<pcl::PointXYZL> point_cloud;
+
+int
+main(int argc, char **argv)
+{
+    point_cloud::Ptr cloud (new point_cloud);
+    point_cloud::Ptr cropped (new point_cloud);
+
+    std::string input_file;
+    std::string output_file;
+
+    std::vector<float> boundaries(6);
+    pcl::console::parse_x_arguments(argc, argv, "-b", boundaries);
+
+    char opt_f[] = "-f";
+    char opt_o[] = "-o";
+    pcl::console::parse_argument(argc, (char**)argv, opt_f, input_file);
+    pcl::console::parse_argument(argc, (char**)argv, opt_o, output_file);
+    for (auto const& v : boundaries)
+    {
+        std::cout << v << " " << std::flush;
+    }
+    std::cout << std::endl;
+
+    float minX = boundaries[0], minY = boundaries[2], minZ = boundaries[4];
+    float maxX = boundaries[1], maxY = boundaries[3], maxZ = boundaries[5];
+
+
+    std::cout << "Loading file" << std::endl;
+    pcl::io::loadPCDFile<pcl::PointXYZL>(input_file, *cloud);
+
+    pcl::CropBox<pcl::PointXYZL> boxFilter;
+    boxFilter.setMin(Eigen::Vector4f(minX, minY, minZ, 1.0));
+    boxFilter.setMax(Eigen::Vector4f(maxX, maxY, maxZ, 1.0));
+    boxFilter.setInputCloud(cloud);
+    boxFilter.filter(*cropped);
+
+    pcl::SampleConsensusModelPlane<pcl::PointXYZL>::Ptr model_p (new pcl::SampleConsensusModelPlane<pcl::PointXYZL> (cropped));
+    pcl::RandomSampleConsensus<pcl::PointXYZL> ransac (model_p);
+    ransac.setDistanceThreshold (.01);
+
+    std::cout << "Computing plane" << std::endl;
+    ransac.computeModel();
+    Eigen::VectorXf coeff;
+    ransac.getModelCoefficients(coeff);
+
+    struct DistanceData {
+        double distance_signed;
+        int laser_id;
+        float* data;
+    };
+
+    std::vector<DistanceData> dists;
+
+    for (auto & it : *cropped)
+    {
+        DistanceData d{};
+        d.distance_signed = pcl::pointToPlaneDistanceSigned(it, coeff);
+        d.laser_id = it.label;
+        d.data = it.data;
+        dists.emplace_back(d);
+    }
+
+    ofstream myfile;
+    myfile.open(output_file);
+
+    for (auto & dist : dists)
+    {
+        myfile << dist.distance_signed << " " << dist.data[0] << " " << dist.data[1] << " " << dist.data[2] << " " << dist.data[3] << " " << dist.laser_id << std::endl;
+    }
+    myfile.close();
+
+    pcl::visualization::PCLVisualizer viz;
+    viz.setBackgroundColor(255, 255, 255);
+    pcl::visualization::PointCloudColorHandlerLabelField<pcl::PointXYZL> color(cropped);
+    viz.addPointCloud<pcl::PointXYZL>(cropped, color, "wall");
+    viz.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "wall");
+    viz.spin();
+}

--- a/src/load_data.cpp
+++ b/src/load_data.cpp
@@ -68,19 +68,19 @@ load_fragments(const std::string fragments_path, const int fragments_number)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
-std::vector<pcl::PointCloud<pcl::PointXYZ> >
+std::vector<pcl::PointCloud<pcl::PointXYZL> >
 load_datapackets_in_one_scan(const int scan_number, const std::string datapackets_path)
 {
     constexpr int pos_scan_number = 5;
     path p(datapackets_path);
-    std::vector<pcl::PointCloud<pcl::PointXYZ> > clouds;
+    std::vector<pcl::PointCloud<pcl::PointXYZL> > clouds;
     for (auto i = directory_iterator(p); i != directory_iterator(); ++i) {
         std::string file = i->path().filename().string();
         if (file == ".DS_Store") { continue; } // If Apple
         std::string scan_file_number = file.substr(pos_scan_number, file.find("_", pos_scan_number) - pos_scan_number);
         if (scan_number == std::stoi(scan_file_number)) {
-            pcl::PointCloud<pcl::PointXYZ> cloud;
-            pcl::io::loadPCDFile<pcl::PointXYZ>(datapackets_path + "/" + file, cloud);
+            pcl::PointCloud<pcl::PointXYZL> cloud;
+            pcl::io::loadPCDFile<pcl::PointXYZL>(datapackets_path + "/" + file, cloud);
             clouds.push_back(cloud);
         }
     }
@@ -88,11 +88,11 @@ load_datapackets_in_one_scan(const int scan_number, const std::string datapacket
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ>>>
+std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL>>>
 load_datapackets(const std::string path)
 {
-    std::vector<std::vector<pcl::PointCloud<pcl::PointXYZ> > > fragment_clouds;
-    std::vector<pcl::PointCloud<pcl::PointXYZ> > datapackets_scan_clouds;
+    std::vector<std::vector<pcl::PointCloud<pcl::PointXYZL> > > fragment_clouds;
+    std::vector<pcl::PointCloud<pcl::PointXYZL> > datapackets_scan_clouds;
     int n_scans = number_of_scans(path);
     for (int i = 0; i < n_scans; ++i) {
         datapackets_scan_clouds = load_datapackets_in_one_scan(i, path);

--- a/src/load_data.cpp
+++ b/src/load_data.cpp
@@ -102,7 +102,7 @@ load_datapackets(const std::string path)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void read_quaternions_file( quart_vector_t& quaternions, const std::string path)
+void read_quaternions_file(quart_vector_t& quaternions, const std::string path)
 {
     std::ifstream input(path + "/" + "quaternions_datapacket.csv");
     const std::string delimiter = ",";
@@ -124,8 +124,8 @@ void read_quaternions_file( quart_vector_t& quaternions, const std::string path)
             quat(j) = row[j];
         }
         double time = row[4];
-        quaternions.first .push_back( quat );
-        quaternions.second.push_back( time );
+        quaternions.first.push_back(quat);
+        quaternions.second.push_back(time);
     }
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/load_data.cpp
+++ b/src/load_data.cpp
@@ -124,7 +124,7 @@ void read_quaternions_file(quart_vector_t& quaternions, const std::string path)
             quat(j) = row[j];
         }
         double time = row[4];
-        quaternions.first.push_back(quat);
+        quaternions.first .push_back(quat);
         quaternions.second.push_back(time);
     }
 }

--- a/src/quaternion_interpolation.cpp
+++ b/src/quaternion_interpolation.cpp
@@ -17,10 +17,6 @@ interpolate_quaternions( vector4d_t& interpolated_quaternions,
 {
     quart_vector_t interpolated_quaternions_time;
     vector4d_t equal_quaternions;
-std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>
-interpolate_quaternions(const std::vector<std::pair<Eigen::Vector4d, double>, Eigen::aligned_allocator<std::pair<Eigen::Vector4d, double>> > &quaternions_time) {
-    std::vector<std::pair<Eigen::Vector4d, double>, Eigen::aligned_allocator<std::pair<Eigen::Vector4d, double>>> interpolated_quaternions_time;
-    std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>> equal_quaternions;
     std::vector<double> timestamp;
     Eigen::Vector4d previous_quaternion{1000, 1000, 1000, 1000};  // initialization of variable
     Eigen::Vector4d a, b, q, diff_quat;
@@ -82,34 +78,17 @@ interpolate_quaternions(const std::vector<std::pair<Eigen::Vector4d, double>, Ei
 
     // Appending the last quaternions if they are all equal
     if (!equal_quaternions.empty()) {
-
-
         for (std::size_t i = 0; i < equal_quaternions.size(); ++i) {
-
             interpolated_quaternions_time.first .push_back( equal_quaternions[i] );
             interpolated_quaternions_time.second.push_back( timestamp[i] );
-
         }
-
-
     }
-
 
     // Remove time
-
-
     interpolated_quaternions.resize( interpolated_quaternions_time.first.size() );
-
     for (std::size_t i = 0; i < interpolated_quaternions_time.first.size(); ++i) {
-
         interpolated_quaternions[i] = interpolated_quaternions_time.first[i];
-
-
     }
-
-
 }
-
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/quaternion_interpolation.cpp
+++ b/src/quaternion_interpolation.cpp
@@ -1,5 +1,6 @@
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #if defined __GNUC__ || defined __APPLE__
 #include <Eigen/Dense>
@@ -16,9 +17,14 @@ interpolate_quaternions( vector4d_t& interpolated_quaternions,
 {
     quart_vector_t interpolated_quaternions_time;
     vector4d_t equal_quaternions;
+std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>
+interpolate_quaternions(const std::vector<std::pair<Eigen::Vector4d, double>, Eigen::aligned_allocator<std::pair<Eigen::Vector4d, double>> > &quaternions_time) {
+    std::vector<std::pair<Eigen::Vector4d, double>, Eigen::aligned_allocator<std::pair<Eigen::Vector4d, double>>> interpolated_quaternions_time;
+    std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>> equal_quaternions;
     std::vector<double> timestamp;
     Eigen::Vector4d previous_quaternion{1000, 1000, 1000, 1000};  // initialization of variable
     Eigen::Vector4d a, b, q, diff_quat;
+
     double diff_time, previous_time = 0;
     for (std::size_t i = 0; i < quaternions_time.first.size(); ++i) {
         if (previous_quaternion.isApprox(quaternions_time.first[i])) {


### PR DESCRIPTION
- also using Eigen::aligned_allocator (which Carsten already merged, so no changes).
- using PointXYZL eveywhere (storing the vertical component inside the label, this has a 1to1 mapping to laser_id as well, could just as well store the laser_id in the label)
- adding option to apply vertical correction as specified in the sensor manual (note: this correction can be applied easily on already existing point clouds as well if the cloud has information about which point comes from which laser)
- adding executable for manual cropping of point clouds, fitting a plane to the cropped point, calculating the signed distances to the fitted wall from all points and saving them to a file (I use this in my error estimation exploration/calculation)
