### PR TITLE
Nicp helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,6 @@ add_executable(reconstruct reconstruction++.cpp
 target_link_libraries(reconstruct ${PCL_LIBRARIES} ${Boost_LIBRARIES})
 
 add_subdirectory(interpolation_data_collection)
+
+add_subdirectory(pcd2nicp)
+

--- a/pcd2nicp/CMakeLists.txt
+++ b/pcd2nicp/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+
+project(pcd2nicp)
+
+set(CMAKE_CXX_STANDARD 11)
+
+# Find package boost
+
+# set(BOOST_ROOT "/usr/local/Cellar/boost/")
+find_package(Boost COMPONENTS system)
+
+set(HAVE_BOOST)
+if(Boost_FOUND)
+    set(HAVE_BOOST "-DHAVE_BOOST")
+endif()
+
+# Find package PCL
+
+find_package(PCL 1.5 REQUIRED)
+
+# Additional include directories
+
+include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${PCL_INCLUDE_DIRS})
+
+# Add definitions
+
+add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
+add_definitions(${HAVE_BOOST})
+add_definitions(${PCL_DEFINITIONS})
+
+################################################################################
+# Converter from PCD to NICP
+################################################################################
+add_executable(pcd2nicp
+               pcd2nicp.cpp)
+target_link_directories(pcd2nicp
+                        PUBLIC ${Boost_LIBRARY_DIRS}
+			${PCL_LIBRARY_DIRS})
+target_link_libraries(pcd2nicp
+                      ${Boost_LIBRARIES}
+                      ${PCL_LIBRARIES})
+
+################################################################################
+# Converter from binary NICP to textualNICP
+################################################################################
+
+add_executable(nicpb2nicp
+               nicpb2nicp.cpp)
+target_link_directories(nicpb2nicp
+                        PUBLIC ${Boost_LIBRARY_DIRS}
+			${PCL_LIBRARY_DIRS})
+target_link_libraries(nicpb2nicp
+                      ${Boost_LIBRARIES}
+                      ${PCL_LIBRARIES})
+

--- a/pcd2nicp/nicpb2nicp.cpp
+++ b/pcd2nicp/nicpb2nicp.cpp
@@ -1,0 +1,132 @@
+//
+// nicpb2nicp
+// Convert a binary .nicp file to textual .nicp
+//
+// nicp is the input for the nicp tools https://github.com/yorsh87/nicp
+//
+// Carsten Griwodz
+//
+
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <iomanip> // setprecision
+
+#include <cstdlib>
+#include <cstring>
+
+using namespace std;
+
+bool readFirstline( istream& istr, size_t& numpoints )
+{
+    char buf[1024];
+    istr.getline( buf, 1024 );
+
+    istringstream rstr( buf );
+    string cc;
+    bool   binary;
+    
+    rstr >> cc;
+    if( cc != "NICPCLOUD" )
+    {
+        cerr << "Input file does not start with the CC NICPCLOUD." << endl;
+        return false;
+    }
+
+    rstr >> numpoints >> binary;
+
+    if( binary != 1 )
+    {
+        cerr << "Input file is already in test format, nothing to do." << endl;
+        return false;
+    }
+
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        cerr << "Usage: " << argv[0] << " <binary-in>.nicp <ascii-out>.nicp" << endl
+             << "       Takes a binary input file in NICP format and converts it" << endl
+             << "       to a NICP file in text format." << endl;
+        return -1;
+    }
+
+    string infile_name( argv[1] );
+    string outfile_name( argv[2] );
+
+    ifstream istr( infile_name );
+    if( ! istr.good() )
+    {
+        cerr << "Failed to open input file named " << infile_name << " to read NICP point cloud input" << endl;
+        return -1;
+    }
+
+    ofstream ostr( outfile_name );
+
+    if( ! ostr.good() )
+    {
+        cerr << "Failed to open output file named " << outfile_name << " to write NICP point cloud output" << endl;
+        return -1;
+    }
+
+    size_t numPoints = 0;
+
+    if( ! readFirstline( istr, numPoints ) )
+    {
+        return -1;
+    }
+    cerr << "Input file contains " << numPoints << " samples." << endl;
+
+    ostr << "NICPCLOUD " << numPoints << " 0" << endl;
+
+    int transform[6];
+    istr >> transform[0] >> transform[1] >> transform[2] >> transform[3] >> transform[4] >> transform[1];
+
+    cerr << "Transform line contains "
+         << transform[0] << " " << transform[1] << " " << transform[2] << " "
+         << transform[3] << " " << transform[4] << " " << transform[1] << endl;
+
+    ostr << transform[0] << " " << transform[1] << " " << transform[2] << " "
+         << transform[3] << " " << transform[4] << " " << transform[1] << endl;
+
+    cerr << "Reading " << numPoints << " points." << endl;
+
+    for( size_t i=0; i<numPoints; i++ )
+    {
+        float values[3+3+16];
+        const size_t sz = (3+3+16)*sizeof(float);
+        istr.read( (char*)values, sz );
+        if( !istr.good() )
+        {
+            cerr << "Failed to read point set " << i << " from the input file" << endl;
+            break;
+        }
+
+        ostr << "POINTWITHSTATS";
+        for( int j=0; j<3+3+16; j++ )
+        {
+            float v = values[j];
+            if( std::abs(v) < 0.000001 ) v = 0;
+            ostr << " " << setprecision(3) << v;
+        }
+        ostr << endl;
+    }
+    if( istr.good() )
+    {
+        size_t rest = 0;
+        while( istr.good() )
+        {
+            float in;
+            istr >> in;
+            rest++;
+        }
+        cerr << "Read " << rest << " floats from the input after the expected nunmber of samples."
+             << endl;
+    }
+
+    return 0;
+}
+

--- a/pcd2nicp/pcd2nicp.cpp
+++ b/pcd2nicp/pcd2nicp.cpp
@@ -1,0 +1,75 @@
+//
+// pcd2nicp
+// Convert a .pcd file to .nicp
+//
+// pcd is Point Cloud Data from PCL (PointCloud Library).
+// nicp is the input for the nicp tools https://github.com/yorsh87/nicp
+//
+// Carsten Griwodz
+//
+
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <iomanip> // setprecision
+
+#include <cstdlib>
+#include <cstring>
+
+#include <pcl/common/common.h>
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/console/parse.h>
+
+using namespace std;
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        cerr << "Usage: " << argv[0] << " input.pcd output.nicp" << endl;
+        return -1;
+    }
+
+    string infile_name( argv[1] );
+    string outfile_name( argv[2] );
+
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud( new pcl::PointCloud<pcl::PointXYZ>() );
+
+    if( pcl::io::loadPCDFile<pcl::PointXYZ>( infile_name.c_str(), *cloud ) == -1)
+    {
+        cerr << "Failed to read a point cloud from input file " << infile_name << endl;
+        return -1;
+    }
+
+    // pcl::PointXYZ min_point;
+    // pcl::PointXYZ max_point;
+    // pcl::getMinMax3D( *cloud, min_point, max_point );
+
+    ofstream ostr( outfile_name );
+
+    if( ! ostr.good() )
+    {
+        cerr << "Failed to open file named " << outfile_name << " for NICP point cloud output" << endl;
+        return -1;
+    }
+
+    ostr << "NICPCLOUD " << cloud->size() << " 0" << endl;
+
+    ostr << "0 0 0 0 0 0" << endl;
+
+    for( auto it = cloud->begin(); it != cloud->end(); it++ )
+    {
+        const pcl::PointXYZ& point = *it;
+        ostr << point.x << " " << point.y << " " << point.z
+             << " 1 0 0"
+             << " 1 0 0 0"
+             << " 0 1 0 0"
+             << " 0 0 1 0"
+             << " 0 0 0 1" << endl;
+    }
+
+    return 0;
+}
+

--- a/pcd2nicp/pcd2nicp.cpp
+++ b/pcd2nicp/pcd2nicp.cpp
@@ -62,7 +62,8 @@ int main(int argc, char **argv)
     for( auto it = cloud->begin(); it != cloud->end(); it++ )
     {
         const pcl::PointXYZ& point = *it;
-        ostr << point.x << " " << point.y << " " << point.z
+        ostr << "POINTWITHSTAT "
+             << point.x << " " << point.y << " " << point.z
              << " 1 0 0"
              << " 1 0 0 0"
              << " 0 1 0 0"


### PR DESCRIPTION
NICP is an ICP that uses normals for coarse alignment.
It can be found on github and has a GPL license: [yorsh87/nicp.git](https://github.com/yorsh87/nicp.git)
To begin testing it, we must be able to convert PCD files to NICP format. This is not trivial because the NICP code does not include any converters, and NICP takes a 22-float-per-point format (3 coordinate, 3 normal, 16 statistics).
This commit is an initial attempt at conversion.

It should be relatively easy to add normals using the existing PCL functions, but the statistics is unclear.